### PR TITLE
Remove IAM User and stop running Docker as root

### DIFF
--- a/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
+++ b/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
@@ -27,7 +27,17 @@
     "taskDefinitionRole" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
-        "Path" : "/",
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [ {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ecs-tasks.amazonaws.com" ]
+            },
+            "Action": [ "sts:AssumeRole" ]
+          } ]
+        },
+        "Path": "/",
         "Policies" : [ {
           "PolicyName" : "accesstonewss3anddynamodb",
           "PolicyDocument" : {
@@ -54,7 +64,6 @@
             "Name": "linn-news",
             "Cpu": "1",
             "Essential": "true",
-            "User": "linn-news",
             "Image": { "Fn::Join" :  [ "", [ "docker.io/linn/news:", { "Ref" : "dockerTag" } ]]},
             "Memory": "100",
             "PortMappings": [

--- a/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
+++ b/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
@@ -64,6 +64,7 @@
             "Name": "linn-news",
             "Cpu": "1",
             "Essential": "true",
+            "User": "service-user",
             "Image": { "Fn::Join" :  [ "", [ "docker.io/linn/news:", { "Ref" : "dockerTag" } ]]},
             "Memory": "100",
             "PortMappings": [

--- a/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
+++ b/ContinuousIntegration/CloudFormation/newsAppCloudFormation.json
@@ -17,11 +17,15 @@
     "newsAttachmentsBucket" : {
       "Type" : "String",
       "Description" : "S3 Bucket to store news article attachements"
+    },
+    "albTargetGroupArn": {
+      "Type": "String",
+      "Description": "Target Group ARN for news application"
     }
   },
   "Resources": {
-    "newsUser" : {
-      "Type" : "AWS::IAM::User",
+    "taskDefinitionRole" : {
+      "Type" : "AWS::IAM::Role",
       "Properties" : {
         "Path" : "/",
         "Policies" : [ {
@@ -41,25 +45,20 @@
         } ]
       }
     },
-    "newsAccesskey" : {
-      "Type" : "AWS::IAM::AccessKey",
-      "Properties" : {
-        "UserName" : { "Ref" : "newsUser" }
-      }
-    },
     "taskDefinition": {
       "Type": "AWS::ECS::TaskDefinition",
       "Properties": {
+        "TaskRoleArn": {"Fn::GetAtt" : ["taskDefinitionRole", "Arn"] },
         "ContainerDefinitions": [
           {
-            "Name": "Linn-News",
+            "Name": "linn-news",
             "Cpu": "1",
             "Essential": "true",
+            "User": "linn-news",
             "Image": { "Fn::Join" :  [ "", [ "docker.io/linn/news:", { "Ref" : "dockerTag" } ]]},
             "Memory": "100",
             "PortMappings": [
               {
-                "HostPort": 60350,
                 "ContainerPort": 3000
               }
             ],
@@ -67,14 +66,6 @@
               {
                 "Name": "AWS_REGION",
                 "Value": { "Ref": "AWS::Region" }
-              },
-              {
-                "Name": "AWS_ACCESS_KEY_ID",
-                "Value": { "Ref": "newsAccesskey" }
-              },
-              {
-                "Name": "AWS_SECRET_ACCESS_KEY",
-                "Value": { "Fn::GetAtt": [ "newsAccesskey", "SecretAccessKey" ] }
               },
               {
                 "Name": "NEWS_TABLE_NAME",
@@ -101,8 +92,18 @@
       "Type": "AWS::ECS::Service",
       "Properties" : {
         "Cluster": { "Ref":"targetCluster" },
-        "DesiredCount": "1",
-        "TaskDefinition" : {"Ref":"taskDefinition"}
+        "DesiredCount": "2",
+        "TaskDefinition" : {"Ref":"taskDefinition"},
+        "Role": "ecsServiceRole",
+        "LoadBalancers": [
+          {
+            "ContainerName": "linn-news",
+            "ContainerPort": 3000,
+            "TargetGroupArn": {
+              "Ref": "albTargetGroupArn"
+            }
+          }
+        ]
       }
     }
   }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ EXPOSE 3000
 
 WORKDIR /usr/src/app
 
+# Add service-user user so we aren't running as root.
+RUN adduser -h /usr/src/service-user -D -H service-user && && chown -R service-user:service-user /usr/src/app
+
+USER service-user
+
 COPY . /usr/src/app
 
 RUN npm install --production --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,17 @@ FROM node:4-slim
 
 EXPOSE 3000
 
+ARG USER=service-user
+
 WORKDIR /usr/src/app
-
-# Add service-user user so we aren't running as root.
-RUN adduser -h /usr/src/service-user -D -H service-user && && chown -R service-user:service-user /usr/src/app
-
-USER service-user
 
 COPY . /usr/src/app
 
 RUN npm install --production --quiet
+
+RUN useradd -ms /bin/bash -d /usr/src/app $USER
+RUN chown $USER:$USER /usr/src/app
+USER $USER
+
 
 CMD [ "npm", "start" ]

--- a/config/index.js
+++ b/config/index.js
@@ -23,16 +23,6 @@ let cfg = config({
         type     : 'string',
         required : true
     },
-    awsAccessKeyId : {
-        env      : 'AWS_ACCESS_KEY_ID',
-        type     : 'string',
-        required : true
-    },
-    awsSecretAccessKey : {
-        env      : 'AWS_SECRET_ACCESS_KEY',
-        type     : 'string',
-        required : true
-    },
     port : {
         env      : 'PORT',
         type     : 'integer',

--- a/package.json
+++ b/package.json
@@ -8,25 +8,25 @@
     "test": "node node_modules/mocha/bin/mocha --recursive -R spec test/"
   },
   "dependencies": {
-    "12factor-config": "^1.1.0",
-    "async": "^0.9.0",
-    "aws-sdk": "^2.1.16",
+    "12factor-config": "^1.2.1",
+    "async": "^2.0.1",
+    "aws-sdk": "^2.4.9",
     "body-parser": "~1.10.2",
-    "bower": "^1.3.1",
+    "bower": "^1.7.9",
     "cookie-parser": "~1.3.3",
     "debug": "~2.1.1",
     "dotenv": "^1.2.0",
     "express": "~4.11.1",
     "jade": "~1.9.1",
-    "moment": "^2.9.0",
+    "moment": "^2.14.1",
     "morgan": "~1.5.1",
     "multiparty": "^4.1.1",
     "node-markdown": "^0.1.1",
     "node-uuid": "^1.4.3",
-    "repository-dynamodb": "^0.9.6",
+    "repository-dynamodb": "^0.9.7",
     "serve-favicon": "~2.2.0",
     "underscore": "^1.8.2",
-    "winston": "^2.1.1"
+    "winston": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
This removes the requirement of an IAM User in favour of using task defition roles. The Docker is now configured to run as a non root user. 

It also registers with a target group so can be load balanced by an ALB. 