### PR TITLE
Use ecr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
   - aws ecr get-login --no-include-email --region eu-west-1 | sh
   - make build
 script:
-  - make test
   - make all-the-dockers
   - make docker-tag
   - make docker-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
   - export PATH=~/bin:$PATH
 before_script:
   - aws ecr get-login --no-include-email --region eu-west-1 | sh
-  - make build
 script:
   - make all-the-dockers
   - make docker-tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ node_js:
 sudo: required
 services:
   - docker
+before_install:
+  - curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+  - unzip awscli-bundle.zip
+  - ./awscli-bundle/install -b ~/bin/aws
+  - export PATH=~/bin:$PATH
 before_script:
-  - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD -e $DOCKER_HUB_EMAIL
+  - `aws ecr get-login --no-include-email --region eu-west-1`
 after_success:
   - make all-the-dockers
   - make docker-tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ before_install:
   - export PATH=~/bin:$PATH
 before_script:
   - aws ecr get-login --no-include-email --region eu-west-1 | sh
-after_success:
+  - make build
+script:
+  - make test
   - make all-the-dockers
   - make docker-tag
   - make docker-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
   - ./awscli-bundle/install -b ~/bin/aws
   - export PATH=~/bin:$PATH
 before_script:
-  - aws ecr get-login --no-include-email --region eu-west-1 > docker_login.sh
-  - chmod +x docker_login.sh
-  - ./docker_login.sh
+  - aws ecr get-login --no-include-email --region eu-west-1 | sh
 after_success:
   - make all-the-dockers
   - make docker-tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_install:
   - ./awscli-bundle/install -b ~/bin/aws
   - export PATH=~/bin:$PATH
 before_script:
-  - `aws ecr get-login --no-include-email --region eu-west-1`
+  - aws ecr get-login --no-include-email --region eu-west-1 > docker_login.sh
+  - chmod +x docker_login.sh
+  - ./docker_login.sh
 after_success:
   - make all-the-dockers
   - make docker-tag

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER := linn/news
+DOCKER := 545349016803.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
 DOCKER_BRANCH_TAG := $(shell echo ${TRAVIS_BRANCH} | sed s/\#/_/g)
 TIMESTAMP := $(shell date --utc +%FT%TZ)
 PINGJSON := ping.json

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ PINGJSON := ping.json
 
 define tag_docker
 	@if [ "$(TRAVIS_BRANCH)" != "master" ]; then \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):BUILD$(DOCKER_BRANCH_TAG); \
+		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):BUILD$(DOCKER_BRANCH_TAG); \
 	fi
 	@if [ "$(TRAVIS_BRANCH)" = "master" -a "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):latest; \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):K$(TRAVIS_BUILD_NUMBER); \
+		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):latest; \
+		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):K$(TRAVIS_BUILD_NUMBER); \
 	fi
 	@if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):PR$(TRAVIS_PULL_REQUEST); \
+		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):PR$(TRAVIS_PULL_REQUEST); \
 	fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER := 545349016803.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
+DOCKER := 545349016803.dkr.ecr.eu-west-1.amazonaws.com/news
 DOCKER_BRANCH_TAG := $(shell echo ${TRAVIS_BRANCH} | sed s/\#/_/g)
 TIMESTAMP := $(shell date --utc +%FT%TZ)
 PINGJSON := ping.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER := 545349016803.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
+DOCKER := linnproducts.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
 DOCKER_BRANCH_TAG := $(shell echo ${TRAVIS_BRANCH} | sed s/\#/_/g)
 TIMESTAMP := $(shell date --utc +%FT%TZ)
 PINGJSON := ping.json

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ PINGJSON := ping.json
 
 define tag_docker
 	@if [ "$(TRAVIS_BRANCH)" != "master" ]; then \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):$(DOCKER_BRANCH_TAG); \
+		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):BUILD$(DOCKER_BRANCH_TAG); \
 	fi
 	@if [ "$(TRAVIS_BRANCH)" = "master" -a "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
 		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):latest; \
 		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):K$(TRAVIS_BUILD_NUMBER); \
 	fi
 	@if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):PR_$(TRAVIS_PULL_REQUEST); \
+		docker tag $(1):$(TRAVIS_BUILD_NUMBER) $(1):PR$(TRAVIS_PULL_REQUEST); \
 	fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: build $(PINGJSON)
 	NODE_ENV=test npm test
 
 $(DOCKER): build
-	docker build -t $(DOCKER):$(TRAVIS_BUILD_NUMBER) .
+	docker build -t $(DOCKER):BUILD$(TRAVIS_BUILD_NUMBER) .
 	
 all-the-dockers: $(DOCKER)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER := linnproducts.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
+DOCKER := 545349016803.dkr.ecr.eu-west-1.amazonaws.com/ecr-newsrep-z29e7go0aydv
 DOCKER_BRANCH_TAG := $(shell echo ${TRAVIS_BRANCH} | sed s/\#/_/g)
 TIMESTAMP := $(shell date --utc +%FT%TZ)
 PINGJSON := ping.json
@@ -25,7 +25,7 @@ $(PINGJSON):
 test: build $(PINGJSON)
 	NODE_ENV=test npm test
 
-$(DOCKER): build
+$(DOCKER): build test
 	docker build -t $(DOCKER):BUILD_$(TRAVIS_BUILD_NUMBER) .
 	
 all-the-dockers: $(DOCKER)

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ PINGJSON := ping.json
 
 define tag_docker
 	@if [ "$(TRAVIS_BRANCH)" != "master" ]; then \
-		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):BUILD$(DOCKER_BRANCH_TAG); \
+		docker tag $(1):BUILD_$(TRAVIS_BUILD_NUMBER) $(1):BUILD_$(DOCKER_BRANCH_TAG); \
 	fi
 	@if [ "$(TRAVIS_BRANCH)" = "master" -a "$(TRAVIS_PULL_REQUEST)" = "false" ]; then \
-		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):latest; \
-		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):K$(TRAVIS_BUILD_NUMBER); \
+		docker tag $(1):BUILD_$(TRAVIS_BUILD_NUMBER) $(1):latest; \
+		docker tag $(1):BUILD_$(TRAVIS_BUILD_NUMBER) $(1):K_$(TRAVIS_BUILD_NUMBER); \
 	fi
 	@if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-		docker tag $(1):BUILD$(TRAVIS_BUILD_NUMBER) $(1):PR$(TRAVIS_PULL_REQUEST); \
+		docker tag $(1):BUILD_$(TRAVIS_BUILD_NUMBER) $(1):PR_$(TRAVIS_PULL_REQUEST); \
 	fi
 endef
 
@@ -26,7 +26,7 @@ test: build $(PINGJSON)
 	NODE_ENV=test npm test
 
 $(DOCKER): build
-	docker build -t $(DOCKER):BUILD$(TRAVIS_BUILD_NUMBER) .
+	docker build -t $(DOCKER):BUILD_$(TRAVIS_BUILD_NUMBER) .
 	
 all-the-dockers: $(DOCKER)
 


### PR DESCRIPTION
Update to send images to AWS ECR rather than Dockerhub

1. Change "docker login" process. 
2. Update repository name from `linn/news` to `545349016803.dkr.ecr.eu-west-1.amazonaws.com/news`. 
3. Prefix build tags with `BUILD_` so they can be expired using ECR lifecycle policy. 